### PR TITLE
feat: add item based collaborative filtering (recommendation system)

### DIFF
--- a/scratch-collect.API/Services/Recommendation/IRecommendationService.cs
+++ b/scratch-collect.API/Services/Recommendation/IRecommendationService.cs
@@ -1,0 +1,10 @@
+﻿using scratch_collect.Model;
+using System.Collections.Generic;
+
+namespace scratch_collect.API.Services
+{
+    public interface IRecommendationService
+    {
+        List<OfferDTO> GetRecommendedItems(int itemId);
+    }
+}

--- a/scratch-collect.API/Services/Recommendation/RecommendationService.cs
+++ b/scratch-collect.API/Services/Recommendation/RecommendationService.cs
@@ -1,0 +1,147 @@
+﻿using AutoMapper;
+using Microsoft.EntityFrameworkCore;
+using scratch_collect.API.Database;
+using scratch_collect.Model;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace scratch_collect.API.Services
+{
+    public class RecommendationService : IRecommendationService
+    {
+        private readonly ScratchCollectContext _context;
+        private readonly IMapper _mapper;
+        private DataHelper _helper;
+
+        public RecommendationService(ScratchCollectContext context, IMapper mapper)
+        {
+            _context = context;
+            _mapper = mapper;
+            _helper = new DataHelper(context);
+        }
+
+        private Dictionary<int, List<RatingDTO>> associatedRatings = new Dictionary<int, List<RatingDTO>>();
+
+        private void LoadOtherOffersWithRatings(int itemId)
+        {
+            List<Offer> collectionWithoutCurrentItem = _context.Offers.Where(o => o.Id != itemId).ToList();
+            List<Rating> collectionRatings = new List<Rating>();
+
+            foreach (var item in collectionWithoutCurrentItem)
+            {
+                collectionRatings = _context
+                    .Ratings
+                    .Include(x => x.User)
+                    .Where(r => r.OfferId == item.Id)
+                    .OrderBy(r => r.OfferId)
+                    .ToList();
+
+                if (collectionRatings.Count > 0)
+                {
+                    associatedRatings.Add(item.Id, _mapper.Map<List<RatingDTO>>(collectionRatings));
+                }
+            }
+        }
+
+        private List<RatingDTO> GetCurrentOfferRatings(int itemId)
+        {
+            List<Rating> ratings = _context
+                .Ratings
+                .Include(x => x.User)
+                .Where(r => r.OfferId == itemId)
+                .OrderBy(x => x.UserId)
+                .ToList();
+
+            return _mapper.Map<List<RatingDTO>>(ratings);
+        }
+
+        private double ComputeSimilarityMatrix(List<RatingDTO> firstSet, List<RatingDTO> secondSet)
+        {
+            if (firstSet.Count != secondSet.Count) return 0;
+
+            double x = 0, y1 = 0, y2 = 0;
+            for (int i = 0; i < firstSet.Count; i++)
+            {
+                x += firstSet[i].RateCount * secondSet[i].RateCount;
+                y1 += firstSet[i].RateCount * firstSet[i].RateCount; // Euclidean distance
+                y2 += secondSet[i].RateCount * secondSet[i].RateCount;
+            }
+
+            y1 = Math.Sqrt(y1);
+            y2 = Math.Sqrt(y2);
+            double y = y1 * y2;
+
+            if (y == 0) return 0;
+
+            return x / y;
+        }
+
+        public List<OfferDTO> GetRecommendedItems(int itemId)
+        {
+            LoadOtherOffersWithRatings(itemId);
+            List<RatingDTO> currentOfferRatings = GetCurrentOfferRatings(itemId);
+
+            List<RatingDTO> firstRatingsSet = new List<RatingDTO>();
+            List<RatingDTO> secondRatingsSet = new List<RatingDTO>();
+            List<OfferDTO> recommendedProducts = new List<OfferDTO>();
+
+            const double RATE_SCORE_THRESHOLD = 3.0;
+
+            foreach (var associatedRating in associatedRatings)
+            {
+                foreach (RatingDTO currentRating in currentOfferRatings)
+                {
+                    if (associatedRating.Value.Where(r => r.User.Id == currentRating.User.Id).Count() > 0)
+                    {
+                        firstRatingsSet.Add(currentRating);
+                        secondRatingsSet.Add(associatedRating.Value.Where(w => w.User.Id == currentRating.User.Id).First());
+                    }
+                }
+
+                double similarity = ComputeSimilarityMatrix(firstRatingsSet, secondRatingsSet);
+
+                if (similarity > 0.5)
+                {
+                    var item = _context
+                        .Offers
+                        .Include(x => x.Category)
+                        .Include(x => x.OfferRatings)
+                        .AsQueryable()
+                        // Take into account current stock of item.
+                        // Don't recommend items that have quantity of 0.
+                        .Where(o => o.Id == associatedRating.Key && o.Quantity > 0)
+                        .Select(o => new OfferDTO
+                        {
+                            Id = o.Id,
+                            Title = o.Title,
+                            Description = o.Description,
+                            Quantity = o.Quantity,
+                            RequiredPrice = o.RequiredPrice,
+                            UpdatedAt = o.UpdatedAt,
+                            CreatedAt = o.CreatedAt,
+                            Category = _mapper.Map<CategoryDTO>(o.Category),
+                            AverageRating = _helper.CalculateOfferAverageRating(o.Id)
+                        })
+                        .AsEnumerable()
+                        .Where(x => x.AverageRating > RATE_SCORE_THRESHOLD)
+                        .FirstOrDefault();
+
+                    if (item != null)
+                    {
+                        recommendedProducts.Add(_mapper.Map<OfferDTO>(item));
+                    }
+                }
+
+                firstRatingsSet.Clear();
+                secondRatingsSet.Clear();
+            }
+
+            return recommendedProducts.Count > 0
+                ? recommendedProducts
+                    .Take(5)
+                    .ToList()
+                : new List<OfferDTO>();
+        }
+    }
+}

--- a/scratch-collect.API/Startup.cs
+++ b/scratch-collect.API/Startup.cs
@@ -91,6 +91,7 @@ namespace scratch_collect.API
             services.AddScoped<IPaymentService, PaymentService>();
             services.AddScoped<IReportService, ReportService>();
             services.AddScoped<IRatingService, RatingService>();
+            services.AddScoped<IRecommendationService, RecommendationService>();
 
             services.AddAutoMapper(typeof(Startup));
 


### PR DESCRIPTION
Scope of the PR:
- Add new recommendation service;
- Use recommendation service on the offer details response;

Aim of this PR is to provide something else rather than simple recommendation system that we have in place right now. Without using ML.NET, only solution left that is suitable for us was **item based collaborative filtering(CF).**

I'm trying to calculate similarites between two users on how they rate products and based on their similarities system should predict items that a particular user may like.
Another check in place is that I do not want to recommend items that are **not currently in stock** and I do **not recommend items that have average rating (calculated on system earlier) below 3.0.**

Algorithm uses **Euclidean Distance** score method. To calculate an Euclidean score between two people, first we need to find what products they ranked in common, then for each product, calculate the difference in ranks and square it, when we sum all squares we a get similarity score, all that is need to be done is normalize that score so that it falls between 0 and 1.