### PR TITLE
fix(mobile): force aspect ratio on profile image component

### DIFF
--- a/scratch-collect.Mobile/lib/modules/profile/widgets/profile_pic.dart
+++ b/scratch-collect.Mobile/lib/modules/profile/widgets/profile_pic.dart
@@ -24,9 +24,12 @@ class ProfilePic extends StatelessWidget {
         children: [
           CircleAvatar(
             backgroundColor: tertiaryColor,
-            child: ClipOval(
-              child: Image.memory(
-                base64.decode(profilePhoto ?? ""),
+            child: SizedBox.expand(
+              child: ClipOval(
+                child: Image.memory(
+                  base64.decode(profilePhoto ?? ""),
+                  fit: BoxFit.cover,
+                ),
               ),
             ),
           ),


### PR DESCRIPTION
Scope:
- Force profile avatar component to preserve aspect ratio and not overflow the parent container;